### PR TITLE
Added ability to customize angle between nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ JavaScript library to make Radial menus.. or anything..
 ========
 
 With this library you can create a list of items, with different properties and transform it in a circle.
+
 ###Examples of items
 ```
 var items = [

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ var items = [
 ];
 ```
 
-You can also add custom degrees. 0 will lead to the default angle
+You can also add custom angles. 0 will lead to the default angle
+###[Codepen of custom angles](http://codepen.io/SemicolonExpected/pen/RpyLQx)
 ###Example of degrees
 ```
 var degrees = [

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ var items = [
 ```
 
 You can also add custom angles. 0 will lead to the default angle
+
 ###[Codepen of custom angles](http://codepen.io/SemicolonExpected/pen/RpyLQx)
-###Example of degrees
+
+###Example of angles
 ```
 var degrees = [
 	10,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ var items = [
 	{className: 'icon icon-c', html: 3}
 ];
 ```
+
+You can also add custom degrees. 0 will lead to the default angle
+###Example of degrees
+```
+var degrees = [
+	10,
+	10,
+	10
+];
+```
+You do not need to specify degrees for all nodes, but because each item directly corresponds to each degree, items[0] is degrees[0] degrees, if the nodes you want to be defaulted aren't the last nodes, you will need to declare that index as 0. So if you have 6 items, and you want to make only item 3 and 4 a custom angle, you would need to declare it like so or else it would change the first and second item to 10 degrees:
+```
+var degrees = [
+	0,
+	0,
+	10,
+	10
+];
+```
+Also be aware that if you have a button as one of your nodes, that the first index does not count and you would need to put your custom value starting in the second index (degrees[1]) in this case as long as it is a number, you can put anything in degrees[0] but it is best practice to use 0.
+
 ###Radial default options
 ```
 var options = {

--- a/src/radial.js
+++ b/src/radial.js
@@ -101,12 +101,23 @@
 	}
 	
 	// Class
-	var Radial = function(items, newOptions) {
+	var Radial = function(items, newOptions, degrees) {
 		this.options = extendOpt(options, newOptions || {});
 		this._items = extendOptions(items);
+		if(!(degrees===undefined)){ //if it is NOT undefined
+			for(var i = 0; i<this._items.length; i++){
+				if(!(degrees[i]===undefined)){
+					this._items[i]._alfa = degrees[i];
+				}
+				else{
+					this._items[i]._alfa = 0;
+				}
+			}
+		}
 		this._container = createContainer(this.options.container);
 		this.calc();
 	};
+	
 	
 	Radial.prototype = {
 		
@@ -171,7 +182,28 @@
 		*/
 		calc: function() {
 			var count = (this.options.button) ? this.count()-1 : this.count();
-			var alfa = (this.options.deg > 359) ? 360/count : this.options.deg/(count-1);
+			var newcount = count;
+			var anglesaccountedfor = 0;
+			for(var k = 0; k<this._items.length; k++){
+				anglesaccountedfor += this._items[k]._alfa;
+				if(this._items[k]._alfa != 0 && this.options.button){
+					newcount--;
+				}
+			}
+			if((anglesaccountedfor > this.options.deg) || (anglesaccountedfor > 360)){
+				for(var k = 0; k<this._items.length; k++){
+					this._items[k]._alfa = 0; //if the angles don't add up then reset all values to default
+					anglesaccountedfor = 0;
+					newcount = count;
+				}
+			}
+			var alfa = 0;
+			if(newcount != 0){
+				alfa = (this.options.deg > 359) ? (360-anglesaccountedfor)/newcount : (this.options.deg-anglesaccountedfor)/(newcount-1);
+			}
+			else{
+				alfa = (this.options.deg > 359) ? (360-anglesaccountedfor)/count : (this.options.deg-anglesaccountedfor)/(count-1);
+			}
 			var i = -alfa;
 			var j = 0;
 			if(this.options.button) {
@@ -180,9 +212,15 @@
 				j++;
 				count++;
 			}
-			for(j; j < count; j++) {
-				var newalfa = Math.round(i + alfa);
-				this._items[j]._alfa = newalfa;
+			for(j; j < this._items.length; j++) {
+				if(newcount != 0){
+					var newalfa = (this._items[j]._alfa == 0) ? Math.round(i + alfa) : Math.round(i + this._items[j]._alfa);
+					this._items[j]._alfa = newalfa;
+				}
+				else{
+					var newalfa = Math.round(i + alfa);
+					this._items[j]._alfa += newalfa;
+				}
 				i = newalfa;
 			}
 			


### PR DESCRIPTION
I added a way to add custom degrees for some nodes. So if you want a menu that has unevenly distributed items, you can do that. So if you had 3 radial non button nodes, and you wanted one to be 100 degrees apart from the next and not 120, you could make it 100, 130, 130 degrees apart from each other

To do so I added an optional parameter for degrees you can declare by making a vector full of "degrees." I added a check to make sure degrees is declared, and played with the math a little to make sure that all the nodes that don't have a custom degree are distributed equally around the circle. 

Any undefined degrees ie the degree vector is shorter than item count, the remaining degrees will count as 0. 

If the user's degrees add up to over 360 or whatever max degree they specify, degrees will all reset to 0. 

If the user uses custom degrees for ALL nodes but it adds up to less than 360, then this will add extra angle to compensate. 

If you have any questions feel free to ask. 